### PR TITLE
Add support for JModelica as simulation background

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ outputs
 scripts/py_modelica_exporter/Icons
 scripts/py_modelica_exporter/components.json
 scripts/py_modelica_exporter/modelica.json
+simres_example.json
 
 **/*.pyc
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 #
 # 1. Copy this file to the root of your webgme repository (a clean copy, no node_modules, blobstorage etc.)
 # 2. Build the image
-#     $ docker build -t webgme-om-worker .
+#     $ docker build -t webgme-dss-worker .
 
 # https://github.com/nodejs/docker-node/blob/25f26146ac5b9f74add731b0b078e34411ae5831/8/Dockerfile
 FROM node:carbon

--- a/DockerfileJMod
+++ b/DockerfileJMod
@@ -4,7 +4,7 @@ FROM michaelwetter/ubuntu-1604_jmodelica_trunk:latest
 MAINTAINER Patrik Meijer <patrik.meijer@vanderbilt.edu>
 
 # FIXME: docker-worker-manager should allow for a mapping between plugin-name and worker -> webgme-jm-worker.
-# docker build -f DockerfileJMod -t webgme-om-worker .
+# docker build -f DockerfileJMod -t webgme-dss-worker .
 
 ######################## NVM/NODE/NPM ########################
 USER root

--- a/DockerfileJMod
+++ b/DockerfileJMod
@@ -12,6 +12,8 @@ USER root
 RUN apt-get update \
     && apt-get install build-essential libssl-dev curl git-core -y
 
+# The docker worker manager currently requires the cwd to be /usr/app
+RUN chown developer:developer /usr
 USER developer
 ENV NODE_VERSION 8.9.4
 ENV NVM_DIR ${HOME}/.nvm
@@ -25,18 +27,16 @@ ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 RUN node -v
 
 ######################## WebGME API/Docker worker ###################
-RUN mkdir /${HOME}/app
+
+RUN mkdir /usr/app
 
 # copy app source
-COPY --chown=developer . /${HOME}/app/
+COPY --chown=developer . /usr/app/
 
-WORKDIR /${HOME}/app
+WORKDIR /usr/app
 
 # Install the node-modules.
 RUN npm install
 
 # Uncomment this line if webgme-docker-worker-manager is a node_module
-RUN cp /${HOME}/app/node_modules/webgme-docker-worker-manager/dockerworker.js /${HOME}/app/dockerworker.js
-
-# Make sure to set this correctly here
-ENV NODE_ENV dockerworker
+RUN cp /usr/app/node_modules/webgme-docker-worker-manager/dockerworker.js /usr/app/dockerworker.js

--- a/DockerfileJMod
+++ b/DockerfileJMod
@@ -12,9 +12,10 @@ USER root
 RUN apt-get update \
     && apt-get install build-essential libssl-dev curl git-core -y
 
+USER developer
 ENV NODE_VERSION 8.9.4
 ENV NVM_DIR ${HOME}/.nvm
-USER developer
+
 RUN curl -sL https://raw.githubusercontent.com/creationix/nvm/v0.33.8/install.sh | bash \
     && . $NVM_DIR/nvm.sh \
     && nvm install $NODE_VERSION
@@ -27,7 +28,7 @@ RUN node -v
 RUN mkdir /${HOME}/app
 
 # copy app source
-COPY . /${HOME}/app/
+COPY --chown=developer . /${HOME}/app/
 
 WORKDIR /${HOME}/app
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ It will print out the url (by default localhost:8888)
 For a full deployment you'll need nodejs, mongodb and docker.
 
  1. clone this repo `git clone https://github.com/webgme/webgme-dss.git`
- 2. build the docker worker image `docker build -t webgme-om-worker .`
+ 2. build the docker worker image `docker build -t webgme-dss-worker .` for OpenModelica or `docker build -f DockerfileJMod -t webgme-dss-worker .`
  3. build the front-end (`npm install`) `npm run build`
  4. before starting server make sure to use `config/config.dockerworker.js` via the env. var `NODE_ENV=dockerworker` (alternatively create a config on top of it)
 

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -9,6 +9,9 @@ config.client.appDir = './build';
 config.mongo.uri = 'mongodb://127.0.0.1:27017/multi';
 config.seedProjects.defaultProject = 'Modelica';
 config.plugin.allowServerExecution = true;
+config.plugin.SystemSimulator = {
+    simulationTool: 'OpenModelica',
+};
 
 // Listing:     /assets/decoratorSVGList.json
 // Example:     /assets/DecoratorSVG/Modelica.Electrical.Analog.Basic.Ground.svg

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -10,7 +10,7 @@ config.mongo.uri = 'mongodb://127.0.0.1:27017/multi';
 config.seedProjects.defaultProject = 'Modelica';
 config.plugin.allowServerExecution = true;
 config.plugin.SystemSimulator = {
-    simulationTool: 'OpenModelica',
+    simulationTool: 'Only Code Generation',
 };
 
 // Listing:     /assets/decoratorSVGList.json

--- a/config/config.dockerworker.js
+++ b/config/config.dockerworker.js
@@ -11,7 +11,7 @@ config.server.workerManager.path = 'webgme-docker-worker-manager';
 config.server.workerManager.options = {
     //dockerode: null, // https://github.com/apocas/dockerode#getting-started
     network: 'bridge',
-    image: 'webgme-om-worker',
+    image: 'webgme-dss-worker',
     maxRunningContainers: 4,
     keepContainersAtFailure: true,
     // TODO: This option does not exist yet..

--- a/config/config.dockerworker.js
+++ b/config/config.dockerworker.js
@@ -17,6 +17,6 @@ config.server.workerManager.options = {
     // TODO: This option does not exist yet..
     plugins: ['SystemSimulator'],
 };
-
+config.server.port = 80;
 validateConfig(config);
 module.exports = config;

--- a/config/config.prod.js
+++ b/config/config.prod.js
@@ -1,0 +1,11 @@
+/*eslint-env node*/
+/**
+ * @author pmeijer / https://github.com/pmeijer
+ */
+let config = require('./config.dockerworker'),
+    path = require('path');
+
+
+config.plugin.SystemSimulator.simulationTool = 'JModelica.org';
+config.server.port = 80;
+module.exports = config;

--- a/src/client/LeftPanel/LeftDrawer.jsx
+++ b/src/client/LeftPanel/LeftDrawer.jsx
@@ -98,6 +98,7 @@ class LeftDrawer extends Component {
         this.SystemSimulatorMetadata.configStructure.forEach((configDesc) => {
             if (gmeConfig.plugin.SystemSimulator && gmeConfig.plugin.SystemSimulator[configDesc.name] !== undefined) {
                 configDesc.value = gmeConfig.plugin.SystemSimulator[configDesc.name];
+                configDesc.readOnly = true;
             }
         });
     }

--- a/src/client/LeftPanel/LeftDrawer.jsx
+++ b/src/client/LeftPanel/LeftDrawer.jsx
@@ -90,6 +90,18 @@ class LeftDrawer extends Component {
         checkResult: null,
     };
 
+    constructor(props) {
+        super(props);
+        const gmeConfig = this.props.gmeClient.gmeConfig;
+        this.SystemSimulatorMetadata = JSON.parse(JSON.stringify(SystemSimulatorMetadata));
+
+        this.SystemSimulatorMetadata.configStructure.forEach((configDesc) => {
+            if (gmeConfig.plugin.SystemSimulator && gmeConfig.plugin.SystemSimulator[configDesc.name] !== undefined) {
+                configDesc.value = gmeConfig.plugin.SystemSimulator[configDesc.name];
+            }
+        });
+    }
+
     onUpdateDomains = (data) => {
         const {gmeClient} = this.props;
 
@@ -179,14 +191,14 @@ class LeftDrawer extends Component {
     runSimulator = (config) => {
         const {gmeClient, activeNode} = this.props;
 
-        const pluginId = SystemSimulatorMetadata.id;
+        const pluginId = this.SystemSimulatorMetadata.id;
         this.setState({showSimulator: false});
         if (!config) {
             // Cancelled
             return;
         }
 
-        if (config.runSimulation === false) {
+        if (config.simulationTool === 'Only Code Generation') {
             const context = gmeClient.getCurrentPluginContext(pluginId, activeNode);
             context.pluginConfig = config;
 
@@ -331,7 +343,7 @@ class LeftDrawer extends Component {
 
                 {this.state.showSimulator ?
                     <PluginConfigDialog
-                        metadata={SystemSimulatorMetadata}
+                        metadata={this.SystemSimulatorMetadata}
                         onOK={this.runSimulator}
                     /> : null}
 

--- a/src/plugins/SystemSimulator/SystemSimulator.js
+++ b/src/plugins/SystemSimulator/SystemSimulator.js
@@ -403,7 +403,6 @@ define([
 
         const simPackageFiles = [
             `${modelName}_res.csv`,
-            `${modelName}_init.xml`,
             `${modelName}.mo`,
             `simulate.mos`,
         ]

--- a/src/plugins/SystemSimulator/SystemSimulator.js
+++ b/src/plugins/SystemSimulator/SystemSimulator.js
@@ -405,6 +405,7 @@ define([
             `${modelName}_res.csv`,
             `${modelName}.mo`,
             `simulate.mos`,
+            `simulate.py`,
         ]
 
         return fs.readdir(simOutputDir)

--- a/src/plugins/SystemSimulator/metadata.json
+++ b/src/plugins/SystemSimulator/metadata.json
@@ -22,7 +22,7 @@
         "JModelica.org",
         "OpenModelica"
       ],
-      "readOnly": true
+      "readOnly": false
     },
     {
       "name": "stopTime",

--- a/src/plugins/SystemSimulator/metadata.json
+++ b/src/plugins/SystemSimulator/metadata.json
@@ -12,12 +12,17 @@
   "writeAccessRequired": true,
   "configStructure": [
     {
-      "name": "runSimulation",
-      "displayName": "Run simulation",
-      "description": "Set to true to simulation the model on the server, if false it will return the Modelica code.",
-      "value": false,
-      "valueType": "boolean",
-      "readOnly": false
+      "name": "simulationTool",
+      "displayName": "Simulation Tool",
+      "description": "Which tool will run the simulation or if only code-generation will be done.",
+      "value": "Only Code Generation",
+      "valueType": "string",
+      "valueItems": [
+        "Only Code Generation",
+        "JModelica.org",
+        "OpenModelica"
+      ],
+      "readOnly": true
     },
     {
       "name": "stopTime",

--- a/src/plugins/SystemSimulator/readme.txt.ejs
+++ b/src/plugins/SystemSimulator/readme.txt.ejs
@@ -1,0 +1,28 @@
+Usage:
+
+# OpenModelica
+
+1) Make sure to have an installation of OpenModelica on your machine (download tab https://openmodelica.org/)
+
+2) Open a cmd or terminal in this directory
+
+3) To open model from the editor and run the simulation:
+
+windows:
+    > %OPENMODELICAHOME%\bin\omedit.exe Canvas.mo
+
+linux/macOS
+    $ omedit Canvas.mo
+
+4) To run simulation and generate csv file:
+
+windows:
+    > %OPENMODELICAHOME%\bin\omc.exe simulate.mos
+
+linux/macOS
+    $ omc simulate.mos
+
+
+# JModelica.org
+
+

--- a/src/plugins/SystemSimulator/simulate.mos.ejs
+++ b/src/plugins/SystemSimulator/simulate.mos.ejs
@@ -1,0 +1,4 @@
+// This file is for simulation with OpenModelica
+loadModel(Modelica); getErrorString();
+loadFile("<%-modelName%>.mo"); getErrorString();
+simulate(<%-modelName%>, startTime=0.0, stopTime=<%-stopTime%>, outputFormat="csv"); getErrorString();

--- a/src/plugins/SystemSimulator/simulate.py.ejs
+++ b/src/plugins/SystemSimulator/simulate.py.ejs
@@ -41,7 +41,7 @@ for v_name in res.result_data.name:
 
 import json
 with open('<%-modelName%>_res.json', 'w') as outfile:
-    json.dump({}, outfile)
+    json.dump(res_info, outfile)
 
 with open('<%-modelName%>_res.csv', 'w') as outfile:
     outfile.write('hello')

--- a/src/plugins/SystemSimulator/simulate.py.ejs
+++ b/src/plugins/SystemSimulator/simulate.py.ejs
@@ -5,7 +5,7 @@ from pyfmi import load_fmu
 print 'Loaded python packages from JModelica.'
 # Compile .mo file to fmu executable
 print 'Compiling Modelica model...'
-fmu_name = compile_fmu("<%-modelName%>", "<%-modelName%>.mo")
+fmu_name = compile_fmu('<%-modelName%>', '<%-modelName%>.mo')
 print 'Compilation done!'
 
 # Load the compiled fmu
@@ -17,5 +17,10 @@ print 'Compiled model loaded!'
 print 'Simulation model (this may take a while)...'
 res = model.simulate(final_time=<%-stopTime%>)
 
-# TODO: Handle the result
-print res
+# TODO: Handle the result properly based on res-variable
+import json
+with open('<%-modelName%>_res.json', 'w') as outfile:
+    json.dump({}, outfile)
+
+with open('<%-modelName%>_res.csv', 'w') as outfile:
+    f.write('hello')

--- a/src/plugins/SystemSimulator/simulate.py.ejs
+++ b/src/plugins/SystemSimulator/simulate.py.ejs
@@ -1,0 +1,21 @@
+# This script is for simulation using JModelica.org
+from pymodelica import compile_fmu
+from pyfmi import load_fmu
+
+print 'Loaded python packages from JModelica.'
+# Compile .mo file to fmu executable
+print 'Compiling Modelica model...'
+fmu_name = compile_fmu("<%-modelName%>", "<%-modelName%>.mo")
+print 'Compilation done!'
+
+# Load the compiled fmu
+print 'Loading in compiled model...'
+model = load_fmu(fmu_name)
+print 'Compiled model loaded!'
+
+# Simulate the model
+print 'Simulation model (this may take a while)...'
+res = model.simulate(final_time=<%-stopTime%>)
+
+# TODO: Handle the result
+print res

--- a/src/plugins/SystemSimulator/simulate.py.ejs
+++ b/src/plugins/SystemSimulator/simulate.py.ejs
@@ -17,7 +17,28 @@ print 'Compiled model loaded!'
 print 'Simulating model (this may take a while)...'
 res = model.simulate(final_time=<%-stopTime%>)
 
-# TODO: Handle the result properly based on res-variable
+res_info = {
+    'info': {
+        'name': '<%-modelName%>',
+        'description': ''
+    },
+    'variables': {},
+    'timeSeries': {}
+}
+
+for v_name in res.result_data.name:
+    if res.result_data.is_variable(v_name):
+        # FIXME: res.result_data.description(v_name) throws exception..
+        # What is the correct way of getting description?
+        res_info['variables'][v_name] = {
+            'comment': '',
+            'kind': 'variable',
+            'type': '',
+            'unit': '',
+            'displayUnit': ''
+        }
+        res_info['timeSeries'][v_name] = res[v_name].tolist()
+
 import json
 with open('<%-modelName%>_res.json', 'w') as outfile:
     json.dump({}, outfile)

--- a/src/plugins/SystemSimulator/simulate.py.ejs
+++ b/src/plugins/SystemSimulator/simulate.py.ejs
@@ -14,7 +14,7 @@ model = load_fmu(fmu_name)
 print 'Compiled model loaded!'
 
 # Simulate the model
-print 'Simulation model (this may take a while)...'
+print 'Simulating model (this may take a while)...'
 res = model.simulate(final_time=<%-stopTime%>)
 
 # TODO: Handle the result properly based on res-variable
@@ -23,4 +23,4 @@ with open('<%-modelName%>_res.json', 'w') as outfile:
     json.dump({}, outfile)
 
 with open('<%-modelName%>_res.csv', 'w') as outfile:
-    f.write('hello')
+    outfile.write('hello')

--- a/src/plugins/SystemSimulator/simulate.py.ejs
+++ b/src/plugins/SystemSimulator/simulate.py.ejs
@@ -26,6 +26,8 @@ res_info = {
     'timeSeries': {}
 }
 
+csv_lines = [[] for x in xrange(len(res['time']) + 1)]
+
 for v_name in res.result_data.name:
     if res.result_data.is_variable(v_name):
         # FIXME: res.result_data.description(v_name) throws exception..
@@ -39,9 +41,16 @@ for v_name in res.result_data.name:
         }
         res_info['timeSeries'][v_name] = res[v_name].tolist()
 
+        csv_lines[0].append(v_name)
+        cnt = 1
+        for t_val in res[v_name]:
+            csv_lines[cnt].append(repr(t_val))
+            cnt += 1
+
 import json
 with open('<%-modelName%>_res.json', 'w') as outfile:
     json.dump(res_info, outfile)
 
 with open('<%-modelName%>_res.csv', 'w') as outfile:
-    outfile.write('hello')
+    for csv_line in csv_lines:
+        outfile.write(','.join(csv_line) + '\n')


### PR DESCRIPTION
Configure simulation tool via `config.plugin.SystemSimulator.simulationTool = 'JModelica.org';`

Available options are:
```
   "Only Code Generation"
   "JModelica.org"
   "OpenModelica"
```

To build JModelica docker-worker use `docker build -f DockerfileJMod -t webgme-dss-worker .`
